### PR TITLE
Fix exception logging, so that scheduler writes exceptions to log

### DIFF
--- a/HOLMS.Scheduler/Jobs/QuartzJobBase.cs
+++ b/HOLMS.Scheduler/Jobs/QuartzJobBase.cs
@@ -17,7 +17,7 @@ namespace HOLMS.Scheduler.Jobs {
                 ac.Logger.LogInformation(JobName + " execution completed");
             } catch (Exception ex) {
                 var logger = JobEnvConstructor.GetLogger();
-                logger.LogError($"Caught unhandled exception in {JobGroup}:{JobName}", ex);
+                logger.LogError(new EventId(), ex, $"Caught unhandled exception in {JobGroup}:{JobName}");
                 logger.LogError("Re-throwing to abort the job");
 
                 throw;


### PR DESCRIPTION
Subject says it all.

Encountered when the guarantee authorizer job crashed, but we had no useful debugging output.